### PR TITLE
Add Argo CD Helm deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,89 @@ resource "helm_release" "argocd" {
   namespace  = "argocd"
 
   create_namespace = true
+
+  set {
+    name  = "notifications.enabled"
+    value = "false"
+  }
+
+  set {
+    name  = "dex.enabled"
+    value = "false"
+  }
+
+  set {
+    name  = "applicationSet.enabled"
+    value = "false"
+  }
+
+  set {
+    name  = "controller.resources.limits.cpu"
+    value = "200m"
+  }
+  set {
+    name  = "controller.resources.limits.memory"
+    value = "256Mi"
+  }
+  set {
+    name  = "controller.resources.requests.cpu"
+    value = "100m"
+  }
+  set {
+    name  = "controller.resources.requests.memory"
+    value = "128Mi"
+  }
+
+  set {
+    name  = "server.resources.limits.cpu"
+    value = "200m"
+  }
+  set {
+    name  = "server.resources.limits.memory"
+    value = "256Mi"
+  }
+  set {
+    name  = "server.resources.requests.cpu"
+    value = "100m"
+  }
+  set {
+    name  = "server.resources.requests.memory"
+    value = "128Mi"
+  }
+
+  set {
+    name  = "repoServer.resources.limits.cpu"
+    value = "300m"
+  }
+  set {
+    name  = "repoServer.resources.limits.memory"
+    value = "512Mi"
+  }
+  set {
+    name  = "repoServer.resources.requests.cpu"
+    value = "150m"
+  }
+  set {
+    name  = "repoServer.resources.requests.memory"
+    value = "256Mi"
+  }
+
+  set {
+    name  = "redis.resources.limits.cpu"
+    value = "100m"
+  }
+  set {
+    name  = "redis.resources.limits.memory"
+    value = "256Mi"
+  }
+  set {
+    name  = "redis.resources.requests.cpu"
+    value = "50m"
+  }
+  set {
+    name  = "redis.resources.requests.memory"
+    value = "128Mi"
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- add Kubernetes and Helm providers
- deploy Argo CD into cluster via Helm chart

## Testing
- `terraform fmt -recursive`
- `terraform init` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required providers)*

------
https://chatgpt.com/codex/tasks/task_e_6891c244d31c832695dbc0e6e5d450f9